### PR TITLE
return app icon base64 data

### DIFF
--- a/android/src/main/java/com/getapplist/GetAppListModule.kt
+++ b/android/src/main/java/com/getapplist/GetAppListModule.kt
@@ -8,6 +8,13 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.util.Base64
+import java.io.ByteArrayOutputStream
 
 class GetAppListModule(reactContext: ReactApplicationContext) :
         ReactContextBaseJavaModule(reactContext) {
@@ -32,6 +39,11 @@ class GetAppListModule(reactContext: ReactApplicationContext) :
           app.putString("versionName", packageInfo.versionName)
           app.putString("appName", pm.getApplicationLabel(applicationInfo).toString())
 
+
+          val iconDrawable = pm.getApplicationIcon(applicationInfo)
+          val base64Icon = encodeIconToBase64(iconDrawable)
+
+          app.putString("icon", base64Icon)
           apps.pushMap(app)
         }
       }
@@ -40,6 +52,23 @@ class GetAppListModule(reactContext: ReactApplicationContext) :
       promise.reject("Error", e)
     }
   }
+
+  private fun encodeIconToBase64(iconDrawable: Drawable): String {
+      val bitmap: Bitmap = if (iconDrawable is BitmapDrawable) {
+          iconDrawable.bitmap
+      } else {
+          val bitmap = Bitmap.createBitmap(iconDrawable.intrinsicWidth, iconDrawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+          val canvas = Canvas(bitmap)
+          iconDrawable.setBounds(0, 0, canvas.width, canvas.height)
+          iconDrawable.draw(canvas)
+          bitmap
+      }
+      val byteArrayOutputStream = ByteArrayOutputStream()
+      bitmap.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)
+      val byteArray = byteArrayOutputStream.toByteArray()
+      return Base64.encodeToString(byteArray, Base64.DEFAULT)
+  }
+
 
   companion object {
     const val NAME = "GetAppList"

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,4 +2,5 @@ export interface InstalledApp {
   packageName: string;
   appName: string;
   versionName: string;
+  icon: string;
 }


### PR DESCRIPTION
In this pr, the base64 data of the app icons of the found applications is also returned. It can be used in React native. 